### PR TITLE
Fix for deprecated bare variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,11 +9,11 @@
   register: channel_result
   changed_when: "'already initialized' not in channel_result.stdout"
   failed_when: "channel_result.stderr"
-  with_items: php_pear_channels
+  with_items: "{{ php_pear_channels }}"
 
 - name: Install PEAR libraries.
   command: pear install {{ item }}
   register: pear_result
   changed_when: "'already installed' not in pear_result.stdout"
   failed_when: "pear_result.stderr"
-  with_items: php_pear_libraries
+  with_items: "{{ php_pear_libraries }}"


### PR DESCRIPTION
Fix for this deprecation warnings:

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{php_pear_channels}}'). This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{php_pear_libraries}}'). This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg. 
```
